### PR TITLE
Fix: QR code generates only when button is clicked

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,7 +92,7 @@ class QRGenerator {
         // Real-time preview (debounced)
         this.debounceTimer = null;
         ['input', 'change'].forEach(event => {
-            this.elements.qrText.addEventListener(event, () => this.debounceGenerate());
+            this.elements.qrText.addEventListener('input', () => this.updateCharCount());
             this.elements.size.addEventListener(event, () => this.debounceGenerate());
             this.elements.errorLevel.addEventListener(event, () => this.debounceGenerate());
             this.elements.fgColor.addEventListener(event, () => this.debounceGenerate());


### PR DESCRIPTION
##   Bug Description
Previously, the QR code was generated automatically every time a user typed in the input box even without clicking the "Generate QR Code" button.

##   Fix Implemented
- Removed the `input` event listener that was calling `generateQR()` automatically.
- Now, the QR code is generated **only when the "Generate QR" button is clicked**.
- Improved UX by preventing unwanted QR refreshes while typing.

##   How to Test
1. Type something in the input field → QR should NOT appear.
2. Click on the **Generate QR Code** button → QR should appear correctly.

## ✅ Result
The behavior is now more consistent and user-friendly.  
This fix improves user experience without affecting core functionality.
